### PR TITLE
feat: Add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,30 +1,88 @@
-# Dependencies
-node_modules/
+# Development environment exclusions
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+# OS artifacts
+.DS_Store
+Thumbs.db
+
+# Build artifacts
 dist/
+build/
+*.o
+*.out
+*.exe
+*.dll
+*.so
+*.dylib
+*.class
+*.jar
+*.war
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# Dependency directories
+node_modules/
+vendor/
+jspm_packages/
+bower_components/
 
 # Log files
+*.log
+logs/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+lerna-debug.log*
+pnpm-debug.log*
 
-# Editor directories and files
-.idea
-.vscode
-*.suo
-*.ntvs*
-*.njsproj
-*.sln
-*.sw?
+# Coverage directory
+coverage/
 
-# Optional local config files
-local.env
+# Environment variables
+.env
 .env.local
+.env.development.local
+.env.test.local
+.env.production.local
 
-# Build output
-build/
-*.zip
-*.tar.gz
+# IDE specific files
+*.iml
+*.project
+*.classpath
+*.settings/
 
-# Misc
-.DS_Store
-Thumbs.db
+# Temporary files
+tmp/
+temp/
+cache/
+.cache/
+*.tmp
+*.bak
+*.orig
+
+# Documentation
+docs/_build/
+site/
+website/public/
+.jekyll-cache/
+.jekyll-metadata
+*.pdf # If PDFs are generated from source
+
+# Other
+.eslintcache
+.stylelintcache
+.node_repl_history
+.pnp.*
+.yarn/install-state.gz
+.yarn/cache
+.yarn/unplugged
+.yarn/build-state.yml
+.yarn/install-state.gz
+.yarn-integrity
+.history
+errored-out-downloads/


### PR DESCRIPTION
This commit introduces the .gitignore file to exclude common files and directories that should not be versioned. This includes development environment configurations, OS-specific files, build artifacts, dependency directories (like node_modules), and log files. This helps maintain a clean repository and avoids unnecessary conflicts.